### PR TITLE
Timezone offset

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "clean": "rm -rf build/*",
     "build": "babel src -d build",
     "watch": "npm run build -- -w",
-    "test": "tape 'build/test/**/*.js' | tap-spec",
+    "test": "tape 'build/test/**/*.test.js' | tap-spec && npm run tztest",
+    "tztest": "TZ='Etc/UTC-14:00' tape 'build/test/timezone/**/*.js' | tap-spec",
     "prebuild": "npm run clean",
     "prepublish": "npm run build && npm test"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "babel src -d build",
     "watch": "npm run build -- -w",
     "test": "tape 'build/test/**/*.test.js' | tap-spec && npm run tztest",
-    "tztest": "TZ='Etc/UTC-14:00' tape 'build/test/timezone/**/*.js' | tap-spec",
+    "tztest": "TZ='Pacific/Tongatapu' tape 'build/test/timezone/**/*.js' | tap-spec",
     "prebuild": "npm run clean",
     "prepublish": "npm run build && npm test"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import parser from './parser'
 export const hashPattern = /(#\w+[\w-]*)/g
 export const version = 5
 export default class Entry {
-  constructor(user, message, opts = {}) {
+  constructor(user, message, opts = {}, timezoneOffset) {
     let {
       date = new Date(), 
     } = opts
@@ -19,7 +19,7 @@ export default class Entry {
     this._id = shortid.generate()
     this.message = message
     this.ref = date
-    this.parse(message, date)
+    this.parse(message, date, timezoneOffset)
     this.parseTags(message)
   }
 
@@ -33,8 +33,8 @@ export default class Entry {
     return this
   }
 
-  parse(msg, date) {
-    let d = parser(msg, date)
+  parse(msg, date, timezoneOffset) {
+    let d = parser(msg, date, timezoneOffset)
     if (d.isValid) this.setDates(d)
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import moment from 'moment'
 import parser from './parser'
 
 export const hashPattern = /(#\w+[\w-]*)/g
-export const version = 4
+export const version = 5
 export default class Entry {
   constructor(user, message, opts = {}) {
     let {

--- a/src/index.js
+++ b/src/index.js
@@ -7,9 +7,13 @@ export const hashPattern = /(#\w+[\w-]*)/g
 export const version = 5
 export default class Entry {
   constructor(user, message, opts = {}, timezoneOffset) {
-    let {
-      date = new Date(), 
-    } = opts
+    let { date } = opts
+    if (timezoneOffset && !date) {
+      //  ensure reference date is in users time and zone
+      date = moment().utcOffset(timezoneOffset)
+    } else if (!date) {
+      date = new Date()
+    }
 
     if (typeof message === 'object')
       return this._fromJSON(message)
@@ -18,7 +22,8 @@ export default class Entry {
     this.user = user
     this._id = shortid.generate()
     this.message = message
-    this.ref = date
+    //  ensure ref is a date and not a moment
+    this.ref = new Date(date)
     this.parse(message, date, timezoneOffset)
     this.parseTags(message)
   }

--- a/src/parser.js
+++ b/src/parser.js
@@ -12,9 +12,15 @@ parser.refiners.push(impliedAMEndRefiner)
 parser.refiners.push(impliedPMStartRefiner)
 parser.refiners.push(dayOverlapRefiner)
 
-export default function(str, ref) {
+export default function(str, ref, timezoneOffset) {
   let rslt = parser.parse(str, ref)[0]
   let isValid = rslt && rslt.start && rslt.end
+
+  if (timezoneOffset && isValid) {
+    rslt.start.assign('timezoneOffset', timezoneOffset)
+    rslt.end.assign('timezoneOffset', timezoneOffset)
+  }
+
   let start = isValid ? rslt.start.date() : null
   let end = isValid ? rslt.end.date() : null
   let text = isValid ? rslt.text : null

--- a/src/parser.js
+++ b/src/parser.js
@@ -16,6 +16,7 @@ export default function(str, ref, timezoneOffset) {
   let rslt = parser.parse(str, ref)[0]
   let isValid = rslt && rslt.start && rslt.end
 
+  //  sets timezone to where user is located
   if (timezoneOffset && isValid) {
     rslt.start.assign('timezoneOffset', timezoneOffset)
     rslt.end.assign('timezoneOffset', timezoneOffset)

--- a/src/test/index.test.js
+++ b/src/test/index.test.js
@@ -68,6 +68,19 @@ test('no date defaults to today', t => {
   t.end()
 })
 
+test('set timezone offset', t => {
+  const date = new Date()
+  const msg = '8am-3pm worked on some things'
+  const timezoneOffset = -480
+  const e = new Entry(userId, msg, {}, timezoneOffset)
+  const { start, end } = e.getDates()
+
+  t.equal(moment(start).utc().hour(), 16, 'start is 8am in UTC-08:00')
+  t.equal(moment(end).utc().hour(), 23, 'end is 3pm in UTC-08:00')
+
+  t.end()
+})
+
 test('created date added to entry', t => {
   const today = new Date()  
   const e = new Entry(userId, '8am-5pm working on things')

--- a/src/test/parser.test.js
+++ b/src/test/parser.test.js
@@ -192,3 +192,11 @@ test('proper holiday names', t => {
   t.end()
 })
 
+test('use timezone offset', t => {
+  let {start, end} = parser('8am-10am', undefined, -480)
+
+  t.equals(moment(start).utc().hour(), 16, 'start is 8am in UTC-08:00')
+  t.equals(moment(end).utc().hour(), 18, 'end is 10am in UTC-10:00')
+
+  t.end()
+})

--- a/src/test/timezone/index.test.tz.js
+++ b/src/test/timezone/index.test.tz.js
@@ -1,3 +1,7 @@
+/*
+ * These tests are run in UTC+13 in order to guarantee the parser running in
+ * the next day compared to UTC-12
+ */
 import test from 'tape'
 import moment from 'moment'
 import Entry from '../../'

--- a/src/test/timezone/index.test.tz.js
+++ b/src/test/timezone/index.test.tz.js
@@ -1,0 +1,24 @@
+import test from 'tape'
+import moment from 'moment'
+import Entry from '../../'
+
+test('use timezone offset', t => {
+  const timezoneOffset = -720
+  const e = new Entry(undefined, '1-2pm did some #stuff', {}, timezoneOffset)
+  const { start, end } = e.getDates()
+
+  const yesterday = moment().subtract(1, 'day')
+
+  t.equal(
+    moment(start).utcOffset(timezoneOffset).date(),
+    yesterday.date(),
+    'start is yesterday in relation to server'
+  )
+  t.equal(
+    moment(end).utcOffset(timezoneOffset).date(),
+    yesterday.date(),
+    'end is yesterday in relation to server'
+  )
+
+  t.end()
+})


### PR DESCRIPTION
Allows for passing a timezone offset to the parser.

Currently, the `integration-api` will parse wrong if it is in a different timezone than the user. If someone wants the string '1-2pm' parsed, it will do so in relation to the timezone of the server, which may or may not be the same as the user. 

With the supplied timezone, the parser can get a proper result for the user.